### PR TITLE
Create abstract username/password strategy, create database strategy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,12 @@
     },
     "require-dev": {
         "joomla/test": "~1.0",
+        "joomla/database": "~1.0",
         "phpunit/phpunit": "4.*",
         "squizlabs/php_codesniffer": "1.*"
+    },
+    "suggest": {
+        "joomla/database": "To use the DatabaseStrategy authentication class, install joomla/database"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "suggest": {
         "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use Joomla\\Authentication\\Strategies\\LocalStrategy.",
-        "joomla/database": "Required if you want to use classes in the Joomla\\Authentication\\Strategies\\DatabaseStrategy",
+        "joomla/database": "Required if you want to use Joomla\\Authentication\\Strategies\\DatabaseStrategy",
         "joomla/input": "Required if you want to use classes in the Joomla\\Authentication\\Strategies namespace."
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "squizlabs/php_codesniffer": "1.*"
     },
     "suggest": {
-        "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use Joomla\\Authentication\\Strategies\\LocalStrategy.",
+        "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use Joomla\\Authentication\\AbstractUsernamePasswordAuthenticationStrategy",
         "joomla/database": "Required if you want to use Joomla\\Authentication\\Strategies\\DatabaseStrategy",
-        "joomla/input": "Required if you want to use classes in the Joomla\\Authentication\\Strategies namespace."
+        "joomla/input": "Required if you want to use classes in the Joomla\\Authentication\\Strategies namespace"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "joomla/test": "~1.0",
         "joomla/database": "~1.0",
         "phpunit/phpunit": "4.*",
+        "phpunit/dbunit": "~1.3",
         "squizlabs/php_codesniffer": "1.*"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "suggest": {
         "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use Joomla\\Authentication\\Strategies\\LocalStrategy.",
-        "joomla/database": "To use the DatabaseStrategy authentication class, install joomla/database",
-        "joomla/input": "Required if you want to use Joomla\\Authentication\\Strategies\\LocalStrategy."
+        "joomla/database": "Required if you want to use classes in the Joomla\\Authentication\\Strategies\\DatabaseStrategy",
+        "joomla/input": "Required if you want to use classes in the Joomla\\Authentication\\Strategies namespace."
     },
     "autoload": {
         "psr-4": {

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,11 +1,11 @@
 # Using the Authentication Package
 
 The authentication package provides a decoupled authentication system for providing authentication in your 
-application.  Authentication strategies are swappable.  Currently only a simple local strategy is supported.
+application.  Authentication strategies are swappable.
 
 Authentication would generally be performed in your application by doing the following:
 
-```
+```php
 $credentialStore = array(
 	'user1' => '$2y$12$QjSH496pcT5CEbzjD/vtVeH03tfHKFy36d4J0Ltp3lRtee9HDxY3K',
 	'user2' => '$2y$12$QjSH496pcT5CEbzjD/vtVeH03tfHKFy36d4J0Ltp3lsdgnasdfasd'
@@ -38,15 +38,14 @@ Attempts authentication.  Uses all strategies if the array is empty, or a subset
 
 Gets a hashed array of strategies and authentication results.
 
-```
+```php
 $authentication->getResults();
 
-/** Might return:
- array(
- 	'local' => Authentication::SUCCESS,
- 	'strategy2' => Authentication::MISSING_CREDENTIALS
- )
-**/
+// Might return
+array(
+	'local' => Authentication::SUCCESS,
+	'strategy2' => Authentication::MISSING_CREDENTIALS
+)
 ```
 
 
@@ -54,13 +53,33 @@ $authentication->getResults();
 
 Provides authentication support for local credentials obtained from a ```Joomla\Input\Input``` object.
 
-```
+```php
 $credentialStore = array(
 	'jimbob' => 'agdj4345235',		// username and password hash
 	'joe' => 'sdgjrly435235'		// username and password hash
 )
 
 $strategy = new Authentication\Strategies\LocalStrategy($input, $credentialStore);
+```
+
+
+## class `Authentication\Stragies\DatabaseStrategy`
+
+Provides authentication support for user credentials stored in a ```Joomla\Database\DatabaseDriver``` object
+and obtained via a ```Joomla\Input\Input``` object.  The database details can be configured via an options array:
+
+```php
+use Joomla\Database\DatabaseDriver;
+
+$options = array(
+	'table'           => '#__users', // Name of the database table the user data is stored in
+	'username_column' => 'username', // Name of the column in the database containing usernames
+	'password_column' => 'password', // Name of the column in the database containing passwords
+)
+
+$database = DatabaseDriver::getInstance();
+
+$strategy = new Authentication\Strategies\Database($input, $database, $options);
 ```
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -72,7 +72,7 @@ and obtained via a ```Joomla\Input\Input``` object.  The database details can be
 use Joomla\Database\DatabaseDriver;
 
 $options = array(
-	'table'           => '#__users', // Name of the database table the user data is stored in
+	'database_table'  => '#__users', // Name of the database table the user data is stored in
 	'username_column' => 'username', // Name of the column in the database containing usernames
 	'password_column' => 'password', // Name of the column in the database containing passwords
 )

--- a/src/AbstractUsernamePasswordAuthenticationStrategy.php
+++ b/src/AbstractUsernamePasswordAuthenticationStrategy.php
@@ -16,14 +16,6 @@ namespace Joomla\Authentication;
 abstract class AbstractUsernamePasswordAuthenticationStrategy implements AuthenticationStrategyInterface
 {
 	/**
-	 * The credential store.
-	 *
-	 * @var    array
-	 * @since  __DEPLOY_VERSION__
-	 */
-	private $credentialStore = array();
-
-	/**
 	 * The last authentication status.
 	 *
 	 * @var    integer
@@ -43,14 +35,16 @@ abstract class AbstractUsernamePasswordAuthenticationStrategy implements Authent
 	 */
 	protected function doAuthenticate($username, $password)
 	{
-		if (!isset($this->credentialStore[$username]))
+		$hashedPassword = $this->getHashedPassword($username);
+
+		if ($hashedPassword === false)
 		{
 			$this->status = Authentication::NO_SUCH_USER;
 
 			return false;
 		}
 
-		if (!$this->verifyPassword($username, $password))
+		if (!$this->verifyPassword($username, $password, $hashedPassword))
 		{
 			$this->status = Authentication::INVALID_CREDENTIALS;
 
@@ -63,16 +57,15 @@ abstract class AbstractUsernamePasswordAuthenticationStrategy implements Authent
 	}
 
 	/**
-	 * Get the credential store.
+	 * Retrieve the hashed password for the specified user.
 	 *
-	 * @return  array
+	 * @param   string  $username  Username to lookup.
+	 *
+	 * @return  string|boolean  Hashed password on success or boolean false on failure.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getCredentialStore()
-	{
-		return $this->credentialStore;
-	}
+	abstract protected function getHashedPassword($username);
 
 	/**
 	 * Get the status of the last authentication attempt.
@@ -87,35 +80,18 @@ abstract class AbstractUsernamePasswordAuthenticationStrategy implements Authent
 	}
 
 	/**
-	 * Set the credential store.
-	 *
-	 * @param   array  $credentialStore  Associative array with the username as the key and hashed password as the value.
-	 *
-	 * @return  AbstractAuthenticationStrategy  Method allows chaining
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function setCredentialStore(array $credentialStore = array())
-	{
-		$this->credentialStore = $credentialStore;
-
-		return $this;
-	}
-
-	/**
 	 * Attempt to verify the username and password pair.
 	 *
-	 * @param   string  $username  The username to authenticate.
-	 * @param   string  $password  The password to attempt authentication with.
+	 * @param   string  $username        The username to authenticate.
+	 * @param   string  $password        The password to attempt authentication with.
+	 * @param   string  $hashedPassword  The hashed password to attempt authentication against.
 	 *
 	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function verifyPassword($username, $password)
+	protected function verifyPassword($username, $password, $hashedPassword)
 	{
-		$hash = $this->credentialStore[$username];
-
-		return password_verify($password, $hash);
+		return password_verify($password, $hashedPassword);
 	}
 }

--- a/src/AbstractUsernamePasswordAuthenticationStrategy.php
+++ b/src/AbstractUsernamePasswordAuthenticationStrategy.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Part of the Joomla Framework Authentication Package
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Authentication;
+
+/**
+ * Abstract AuthenticationStrategy for username/password based authentication
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+abstract class AbstractUsernamePasswordAuthenticationStrategy implements AuthenticationStrategyInterface
+{
+	/**
+	 * The credential store.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $credentialStore = array();
+
+	/**
+	 * The last authentication status.
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $status;
+
+	/**
+	 * Attempt to authenticate the username and password pair.
+	 *
+	 * @param   string  $username  The username to authenticate.
+	 * @param   string  $password  The password to attempt authentication with.
+	 *
+	 * @return  string|boolean  A string containing a username if authentication is successful, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function doAuthenticate($username, $password)
+	{
+		if (!isset($this->credentialStore[$username]))
+		{
+			$this->status = Authentication::NO_SUCH_USER;
+
+			return false;
+		}
+
+		if (!$this->verifyPassword($username, $password))
+		{
+			$this->status = Authentication::INVALID_CREDENTIALS;
+
+			return false;
+		}
+
+		$this->status = Authentication::SUCCESS;
+
+		return $username;
+	}
+
+	/**
+	 * Get the credential store.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getCredentialStore()
+	{
+		return $this->credentialStore;
+	}
+
+	/**
+	 * Get the status of the last authentication attempt.
+	 *
+	 * @return  integer  Authentication class constant result.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getResult()
+	{
+		return $this->status;
+	}
+
+	/**
+	 * Set the credential store.
+	 *
+	 * @param   array  $credentialStore  Associative array with the username as the key and hashed password as the value.
+	 *
+	 * @return  AbstractAuthenticationStrategy  Method allows chaining
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setCredentialStore(array $credentialStore = array())
+	{
+		$this->credentialStore = $credentialStore;
+
+		return $this;
+	}
+
+	/**
+	 * Attempt to verify the username and password pair.
+	 *
+	 * @param   string  $username  The username to authenticate.
+	 * @param   string  $password  The password to attempt authentication with.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function verifyPassword($username, $password)
+	{
+		$hash = $this->credentialStore[$username];
+
+		return password_verify($password, $hash);
+	}
+}

--- a/src/Authentication.php
+++ b/src/Authentication.php
@@ -99,22 +99,21 @@ class Authentication
 		}
 		else
 		{
-			$strategies = (array) $strategies;
+			$strategies      = (array) $strategies;
+			$strategyObjects = array();
 
-			foreach ($strategies AS $strategy)
+			foreach ($strategies as $strategy)
 			{
-				if (isset($this->strategies[$strategy]))
-				{
-					$strategyObjects[$strategy] = $this->strategies[$strategy];
-				}
-				else
+				if (!isset($this->strategies[$strategy]))
 				{
 					throw new \RuntimeException('Authentication Strategy Not Found');
 				}
+
+				$strategyObjects[$strategy] = $this->strategies[$strategy];
 			}
 		}
 
-		foreach ($strategyObjects AS $strategy => $strategyObject)
+		foreach ($strategyObjects as $strategy => $strategyObject)
 		{
 			$username = $strategyObject->authenticate();
 

--- a/src/Strategies/DatabaseStrategy.php
+++ b/src/Strategies/DatabaseStrategy.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Part of the Joomla Framework Authentication Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Authentication\Strategies;
+
+use Joomla\Authentication\AbstractUsernamePasswordAuthenticationStrategy;
+use Joomla\Authentication\Authentication;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Input\Input;
+
+/**
+ * Joomla Framework Database Strategy Authentication class
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class LocalStrategy extends AbstractUsernamePasswordAuthenticationStrategy
+{
+	/**
+	 * DatabaseDriver object
+	 *
+	 * @var    DatabaseDriver
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $db;
+
+	/**
+	 * The Input object
+	 *
+	 * @var    Input
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $input;
+
+	/**
+	 * Strategy Constructor
+	 *
+	 * @param   Input           $input     The input object from which to retrieve the request credentials.
+	 * @param   DatabaseDriver  $database  DatabaseDriver for retrieving user credentials.
+	 * @param   array           $options   Optional options array for configuring the credential storage connection.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(Input $input, DatabaseDriver $database, array $options = array())
+	{
+		$this->input = $input;
+		$this->db    = $database;
+
+		$options['table'] = isset($options['db_table']) ? $options['db_table'] : '#__users';
+		$options['username_column'] = isset($options['username_column']) ? $options['username_column'] : 'username';
+		$options['password_column'] = isset($options['password_column']) ? $options['password_column'] : 'password';
+
+		$store = $this->createCredentialStore($options);
+
+		if (empty($store))
+		{
+			throw new \RuntimeException('The credential store is empty.');
+		}
+
+		$this->setCredentialStore($store);
+	}
+
+	/**
+	 * Attempt to authenticate the username and password pair.
+	 *
+	 * @return  string|boolean  A string containing a username if authentication is successful, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function authenticate()
+	{
+		$username = $this->input->get('username', false);
+		$password = $this->input->get('password', false);
+
+		if (!$username || !$password)
+		{
+			$this->status = Authentication::NO_CREDENTIALS;
+
+			return false;
+		}
+
+		return $this->doAuthenticate($username, $password);
+	}
+
+	/**
+	 * Creates the credential store.
+	 *
+	 * @param   array  $options  Options for the database connection
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function createCredentialStore(array $options)
+	{
+		return $this->db->setQuery(
+			$this->db->getQuery(true)
+				->select(array($options['username_column'], $options['password_column']))
+				->from($options['table'])
+		)->loadAssocList($options['username_column'], $options['password_column']);
+	}
+}

--- a/src/Strategies/DatabaseStrategy.php
+++ b/src/Strategies/DatabaseStrategy.php
@@ -58,7 +58,7 @@ class DatabaseStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 		$this->input = $input;
 		$this->db    = $database;
 
-		$options['table'] = isset($options['db_table']) ? $options['db_table'] : '#__users';
+		$options['database_table']  = isset($options['database_table']) ? $options['database_table'] : '#__users';
 		$options['username_column'] = isset($options['username_column']) ? $options['username_column'] : 'username';
 		$options['password_column'] = isset($options['password_column']) ? $options['password_column'] : 'password';
 
@@ -101,7 +101,7 @@ class DatabaseStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 		$password = $this->db->setQuery(
 			$this->db->getQuery(true)
 				->select($this->dbOptions['password_column'])
-				->from($this->dbOptions['table'])
+				->from($this->dbOptions['database_table'])
 				->where($this->dbOptions['username_column'] . ' = ' . $this->db->quote($username))
 		)->loadResult();
 

--- a/src/Strategies/DatabaseStrategy.php
+++ b/src/Strategies/DatabaseStrategy.php
@@ -18,7 +18,7 @@ use Joomla\Input\Input;
  *
  * @since  __DEPLOY_VERSION__
  */
-class LocalStrategy extends AbstractUsernamePasswordAuthenticationStrategy
+class DatabaseStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 {
 	/**
 	 * DatabaseDriver object

--- a/src/Strategies/LocalStrategy.php
+++ b/src/Strategies/LocalStrategy.php
@@ -20,6 +20,14 @@ use Joomla\Input\Input;
 class LocalStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 {
 	/**
+	 * The credential store.
+	 *
+	 * @var    array
+	 * @since  1.0
+	 */
+	private $credentialStore;
+
+	/**
 	 * The Input object
 	 *
 	 * @var    Input
@@ -38,7 +46,7 @@ class LocalStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 	public function __construct(Input $input, $credentialStore)
 	{
 		$this->input = $input;
-		$this->setCredentialStore($credentialStore);
+		$this->credentialStore = $credentialStore;
 	}
 
 	/**
@@ -61,5 +69,24 @@ class LocalStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 		}
 
 		return $this->doAuthenticate($username, $password);
+	}
+
+	/**
+	 * Retrieve the hashed password for the specified user.
+	 *
+	 * @param   string  $username  Username to lookup.
+	 *
+	 * @return  string|boolean  Hashed password on success or boolean false on failure.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getHashedPassword($username)
+	{
+		if (!isset($this->credentialStore[$username]))
+		{
+			return false;
+		}
+
+		return $this->credentialStore[$username];
 	}
 }

--- a/src/Strategies/LocalStrategy.php
+++ b/src/Strategies/LocalStrategy.php
@@ -8,7 +8,7 @@
 
 namespace Joomla\Authentication\Strategies;
 
-use Joomla\Authentication\AuthenticationStrategyInterface;
+use Joomla\Authentication\AbstractUsernamePasswordAuthenticationStrategy;
 use Joomla\Authentication\Authentication;
 use Joomla\Input\Input;
 
@@ -17,7 +17,7 @@ use Joomla\Input\Input;
  *
  * @since  1.0
  */
-class LocalStrategy implements AuthenticationStrategyInterface
+class LocalStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 {
 	/**
 	 * The Input object
@@ -26,22 +26,6 @@ class LocalStrategy implements AuthenticationStrategyInterface
 	 * @since  1.0
 	 */
 	private $input;
-
-	/**
-	 * The credential store.
-	 *
-	 * @var    array
-	 * @since  1.0
-	 */
-	private $credentialStore;
-
-	/**
-	 * The last authentication status.
-	 *
-	 * @var    integer
-	 * @since  1.0
-	 */
-	private $status;
 
 	/**
 	 * Strategy Constructor
@@ -54,7 +38,7 @@ class LocalStrategy implements AuthenticationStrategyInterface
 	public function __construct(Input $input, $credentialStore)
 	{
 		$this->input = $input;
-		$this->credentialStore = $credentialStore;
+		$this->setCredentialStore($credentialStore);
 	}
 
 	/**
@@ -76,40 +60,6 @@ class LocalStrategy implements AuthenticationStrategyInterface
 			return false;
 		}
 
-		if (isset($this->credentialStore[$username]))
-		{
-			$hash = $this->credentialStore[$username];
-		}
-		else
-		{
-			$this->status = Authentication::NO_SUCH_USER;
-
-			return false;
-		}
-
-		if (password_verify($password, $hash))
-		{
-			$this->status = Authentication::SUCCESS;
-
-			return $username;
-		}
-		else
-		{
-			$this->status = Authentication::INVALID_CREDENTIALS;
-
-			return false;
-		}
-	}
-
-	/**
-	 * Get the status of the last authentication attempt.
-	 *
-	 * @return  integer  Authentication class constant result.
-	 *
-	 * @since   1.0
-	 */
-	public function getResult()
-	{
-		return $this->status;
+		return $this->doAuthenticate($username, $password);
 	}
 }

--- a/tests/Strategies/DatabaseStrategyTest.php
+++ b/tests/Strategies/DatabaseStrategyTest.php
@@ -58,14 +58,6 @@ class DatabaseStrategyTest extends TestDatabase
 	}
 
 	/**
-	 * @expectedException  \RuntimeException
-	 */
-	public function testEmptyStore()
-	{
-		new DatabaseStrategy($this->input, self::$driver);
-	}
-
-	/**
 	 * Tests the authenticate method with valid credentials.
 	 */
 	public function testValidPassword()

--- a/tests/Strategies/DatabaseStrategyTest.php
+++ b/tests/Strategies/DatabaseStrategyTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Authentication\Tests\Strategies;
+
+use Joomla\Authentication\Strategies\DatabaseStrategy;
+use Joomla\Authentication\Authentication;
+use Joomla\Input\Input;
+use Joomla\Test\TestDatabase;
+
+/**
+ * Test class for \Joomla\Authentication\Strategies\DatabaseStrategy
+ */
+class DatabaseStrategyTest extends TestDatabase
+{
+	/**
+	 * Inserts a user into the test database
+	 *
+	 * @param   string  $username  Test username
+	 * @param   string  $password  Test hashed password
+	 */
+	private function addUser($username, $password)
+	{
+		// Insert the user into the table
+		$db = self::$driver;
+
+		$db->setQuery(
+			$db->getQuery(true)
+				->insert('#__users')
+				->columns(array('username', 'password'))
+				->values($db->quote($username) . ',' . $db->quote($password))
+		)->execute();
+	}
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 */
+	protected function setUp()
+	{
+		$this->input = $this->getMock('Joomla\\Input\\Input');
+	}
+
+	/**
+	 * Tears down the fixture, for example, close a network connection.
+	 */
+	protected function tearDown()
+	{
+		// Truncate the table
+		$db = self::$driver;
+
+		$db->setQuery(
+			$db->getQuery(true)
+				->delete('#__users')
+		)->execute();
+	}
+
+	/**
+	 * @expectedException  \RuntimeException
+	 */
+	public function testEmptyStore()
+	{
+		new DatabaseStrategy($this->input, self::$driver);
+	}
+
+	/**
+	 * Tests the authenticate method with valid credentials.
+	 */
+	public function testValidPassword()
+	{
+		$this->input->expects($this->any())
+			->method('get')
+			->willReturnArgument(0);
+
+		$this->addUser('username', '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJG');
+
+		$strategy = new DatabaseStrategy($this->input, self::$driver);
+
+		$this->assertEquals('username', $strategy->authenticate());
+		$this->assertEquals(Authentication::SUCCESS, $strategy->getResult());
+	}
+
+	/**
+	 * Tests the authenticate method with invalid credentials.
+	 */
+	public function testInvalidPassword()
+	{
+		$this->input->expects($this->any())
+			->method('get')
+			->willReturnArgument(0);
+
+		$this->addUser('username', '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH');
+
+		$strategy = new DatabaseStrategy($this->input, self::$driver);
+
+		$this->assertEquals(false, $strategy->authenticate());
+		$this->assertEquals(Authentication::INVALID_CREDENTIALS, $strategy->getResult());
+	}
+
+	/**
+	 * Tests the authenticate method with no credentials provided.
+	 */
+	public function testNoPassword()
+	{
+		$this->input->expects($this->any())
+			->method('get')
+			->willReturn(false);
+
+		$this->addUser('username', '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH');
+
+		$strategy = new DatabaseStrategy($this->input, self::$driver);
+
+		$this->assertEquals(false, $strategy->authenticate());
+		$this->assertEquals(Authentication::NO_CREDENTIALS, $strategy->getResult());
+	}
+
+	/**
+	 * Tests the authenticate method with credentials for an unknown user.
+	 */
+	public function testUserNotExist()
+	{
+		$this->input->expects($this->any())
+			->method('get')
+			->willReturnArgument(0);
+
+		$this->addUser('jimbob', '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH');
+
+		$strategy = new DatabaseStrategy($this->input, self::$driver);
+
+		$this->assertEquals(false, $strategy->authenticate());
+		$this->assertEquals(Authentication::NO_SUCH_USER, $strategy->getResult());
+	}
+}

--- a/tests/Strategies/LocalStrategyTest.php
+++ b/tests/Strategies/LocalStrategyTest.php
@@ -4,25 +4,19 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Authentication\Tests;
+namespace Joomla\Authentication\Tests\Strategies;
 
 use Joomla\Authentication\Strategies\LocalStrategy;
 use Joomla\Authentication\Authentication;
 use Joomla\Input\Input;
 
 /**
- * Test class for Authentication
- *
- * @since  1.0
+ * Test class for Joomla\Authentication\Strategies\LocalStrategy
  */
 class LocalStrategyTest extends \PHPUnit_Framework_TestCase
 {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
 	 */
 	protected function setUp()
 	{
@@ -31,16 +25,12 @@ class LocalStrategyTest extends \PHPUnit_Framework_TestCase
 
 	/**
 	 * Tests the authenticate method with valid credentials.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
 	 */
 	public function testValidPassword()
 	{
 		$this->input->expects($this->any())
 			->method('get')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 
 		$credentialStore = array(
 			'username' => '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJG'
@@ -55,16 +45,12 @@ class LocalStrategyTest extends \PHPUnit_Framework_TestCase
 
 	/**
 	 * Tests the authenticate method with invalid credentials.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
 	 */
 	public function testInvalidPassword()
 	{
 		$this->input->expects($this->any())
 			->method('get')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 
 		$credentialStore = array(
 			'username' => '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH'
@@ -79,16 +65,12 @@ class LocalStrategyTest extends \PHPUnit_Framework_TestCase
 
 	/**
 	 * Tests the authenticate method with no credentials provided.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
 	 */
 	public function testNoPassword()
 	{
 		$this->input->expects($this->any())
 			->method('get')
-			->will($this->returnValue(false));
+			->willReturn(false);
 
 		$credentialStore = array(
 			'username' => '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH'
@@ -103,16 +85,12 @@ class LocalStrategyTest extends \PHPUnit_Framework_TestCase
 
 	/**
 	 * Tests the authenticate method with credentials for an unknown user.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
 	 */
 	public function testUserNotExist()
 	{
 		$this->input->expects($this->any())
 			->method('get')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 
 		$credentialStore = array(
 			'jimbob' => '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH'


### PR DESCRIPTION
- Abstracts some of the code in the LocalStrategy into an AbstractUsernamePasswordStrategy object
- Creates a DatabaseStrategy object supporting a credential store based on the application's database (with configurable table and column options)
