### PR TITLE
Run tests against php 7 and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
 
 before_script:
   - composer update


### PR DESCRIPTION
- Allow PHP 7 tests to fail
