### PR TITLE
Move password compat library to suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,18 @@
     "homepage": "https://github.com/joomla-framework/authentication",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10",
-        "joomla/input": "~1.0"
+        "php": ">=5.3.10"
     },
     "require-dev": {
         "ircmaxell/password-compat": "~1.0",
+        "joomla/input": "~1.0",
         "joomla/test": "~1.0",
         "phpunit/phpunit": "4.*",
         "squizlabs/php_codesniffer": "1.*"
     },
     "suggest": {
-        "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use Joomla\\Authentication\\Strategies\\LocalStrategy."
+        "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use Joomla\\Authentication\\Strategies\\LocalStrategy.",
+        "joomla/input": "Required if you want to use Joomla\\Authentication\\Strategies\\LocalStrategy."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,16 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.3.10",
-        "joomla/input": "~1.0",
-        "ircmaxell/password-compat": "~1.0"
+        "joomla/input": "~1.0"
     },
     "require-dev": {
+        "ircmaxell/password-compat": "~1.0",
         "joomla/test": "~1.0",
         "phpunit/phpunit": "4.*",
         "squizlabs/php_codesniffer": "1.*"
+    },
+    "suggest": {
+        "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use Joomla\\Authentication\\Strategies\\LocalStrategy."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The library is only required for PHP 5.3 and 5.4 installations and only if using our supplied `LocalStrategy` object.  As it isn't an interface requirement or used in the `Authentication` class, it should be moved to a suggestion instead of being a hard dependency.
