### PR TITLE
Introduce Password Handler API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "squizlabs/php_codesniffer": "1.*"
     },
     "suggest": {
-        "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use Joomla\\Authentication\\AbstractUsernamePasswordAuthenticationStrategy",
+        "ircmaxell/password-compat": "Required for PHP < 5.5 if you want to use the BCrypt password encoder",
         "joomla/database": "Required if you want to use Joomla\\Authentication\\Strategies\\DatabaseStrategy",
         "joomla/input": "Required if you want to use classes in the Joomla\\Authentication\\Strategies namespace"
     },

--- a/src/AbstractUsernamePasswordAuthenticationStrategy.php
+++ b/src/AbstractUsernamePasswordAuthenticationStrategy.php
@@ -8,6 +8,9 @@
 
 namespace Joomla\Authentication;
 
+use Joomla\Authentication\Password\BCryptHandler;
+use Joomla\Authentication\Password\HandlerInterface;
+
 /**
  * Abstract AuthenticationStrategy for username/password based authentication
  *
@@ -16,12 +19,32 @@ namespace Joomla\Authentication;
 abstract class AbstractUsernamePasswordAuthenticationStrategy implements AuthenticationStrategyInterface
 {
 	/**
+	 * The password handler to validate the password against.
+	 *
+	 * @var    HandlerInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $passwordHandler;
+
+	/**
 	 * The last authentication status.
 	 *
 	 * @var    integer
 	 * @since  1.1.0
 	 */
 	protected $status;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   HandlerInterface  $passwordHandler  The password handler.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(HandlerInterface $passwordHandler = null)
+	{
+		$this->passwordHandler = $passwordHandler ?: new BCryptHandler;
+	}
 
 	/**
 	 * Attempt to authenticate the username and password pair.
@@ -92,6 +115,6 @@ abstract class AbstractUsernamePasswordAuthenticationStrategy implements Authent
 	 */
 	protected function verifyPassword($username, $password, $hashedPassword)
 	{
-		return password_verify($password, $hashedPassword);
+		return $this->passwordHandler->validatePassword($password, $hashedPassword);
 	}
 }

--- a/src/Password/Argon2iHandler.php
+++ b/src/Password/Argon2iHandler.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Part of the Joomla Framework Authentication Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Authentication\Password;
+
+/**
+ * Password handler for Argon2i hashed passwords
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Argon2iHandler implements HandlerInterface
+{
+	/**
+	 * Generate a hash for a plaintext password
+	 *
+	 * @param   string  $plaintext  The plaintext password to validate
+	 * @param   array   $options    Options for the hashing operation
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \LogicException
+	 */
+	public function hashPassword($plaintext, array $options = array())
+	{
+		// Use the password extension if able
+		if (version_compare(PHP_VERSION, '7.2', '>=') && defined('PASSWORD_ARGON2I'))
+		{
+			return password_hash($plaintext, PASSWORD_ARGON2I, $options);
+		}
+
+		// Use the sodium extension (PHP 7.2 native or PECL 2.x) if able
+		if (function_exists('sodium_crypto_pwhash_str_verify'))
+		{
+			$hash = sodium_crypto_pwhash_str(
+				$plaintext,
+				SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE,
+				SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE
+			);
+			sodium_memzero($raw);
+
+			return $hash;
+		}
+
+		// Use the libsodium extension (PECL 1.x) if able
+		if (extension_loaded('libsodium'))
+		{
+			$hash = \Sodium\crypto_pwhash_str(
+				$plaintext,
+				\Sodium\CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE,
+				\Sodium\CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE
+			);
+			\Sodium\memzero($raw);
+
+			return $valid;
+		}
+
+		throw new \LogicException('Argon2i algorithm is not supported.');
+	}
+
+	/**
+	 * Check that the password handler is supported in this environment
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isSupported()
+	{
+		// Check for native PHP engine support in the password extension then fall back to support in the sodium extension
+		return (version_compare(PHP_VERSION, '7.2', '>=') && defined('PASSWORD_ARGON2I'))
+			|| function_exists('sodium_crypto_pwhash_str')
+			|| extension_loaded('libsodium');
+	}
+
+	/**
+	 * Validate a password
+	 *
+	 * @param   string  $plaintext  The plain text password to validate
+	 * @param   string  $hashed     The password hash to validate against
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \LogicException
+	 */
+	public function validatePassword($plaintext, $hashed)
+	{
+		// Use the password extension if able
+		if (version_compare(PHP_VERSION, '7.2', '>=') && defined('PASSWORD_ARGON2I'))
+		{
+			return password_verify($plaintext, $hashed);
+		}
+
+		// Use the sodium extension (PHP 7.2 native or PECL 2.x) if able
+		if (function_exists('sodium_crypto_pwhash_str_verify'))
+		{
+			$valid = sodium_crypto_pwhash_str_verify($hashed, $plaintext);
+			sodium_memzero($plaintext);
+
+			return $valid;
+		}
+
+		// Use the libsodium extension (PECL 1.x) if able
+		if (extension_loaded('libsodium'))
+		{
+			$valid = \Sodium\crypto_pwhash_str_verify($hashed, $plaintext);
+			\Sodium\memzero($plaintext);
+
+			return $valid;
+		}
+
+		throw new \LogicException('Argon2i algorithm is not supported.');
+	}
+}

--- a/src/Password/BCryptHandler.php
+++ b/src/Password/BCryptHandler.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Part of the Joomla Framework Authentication Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Authentication\Password;
+
+/**
+ * Password handler for BCrypt hashed passwords
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BCryptHandler implements HandlerInterface
+{
+	/**
+	 * Generate a hash for a plaintext password
+	 *
+	 * @param   string  $plaintext  The plaintext password to validate
+	 * @param   array   $options    Options for the hashing operation
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function hashPassword($plaintext, array $options = array())
+	{
+		return password_hash($plaintext, PASSWORD_BCRYPT, $options);
+	}
+
+	/**
+	 * Check that the password handler is supported in this environment
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isSupported()
+	{
+		return true;
+	}
+
+	/**
+	 * Validate a password
+	 *
+	 * @param   string  $plaintext  The plain text password to validate
+	 * @param   string  $hashed     The password hash to validate against
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function validatePassword($plaintext, $hashed)
+	{
+		return password_verify($plaintext, $hashed);
+	}
+}

--- a/src/Password/BCryptHandler.php
+++ b/src/Password/BCryptHandler.php
@@ -39,7 +39,8 @@ class BCryptHandler implements HandlerInterface
 	 */
 	public static function isSupported()
 	{
-		return true;
+		// Check the password_verify() function exists, either as part of PHP core or through a polyfill
+		return function_exists('password_verify');
 	}
 
 	/**

--- a/src/Password/HandlerInterface.php
+++ b/src/Password/HandlerInterface.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Part of the Joomla Framework Authentication Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Authentication\Password;
+
+/**
+ * Interface defining a password handler
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface HandlerInterface
+{
+	/**
+	 * Generate a hash for a plaintext password
+	 *
+	 * @param   string  $plaintext  The plaintext password to validate
+	 * @param   array   $options    Options for the hashing operation
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function hashPassword($plaintext, array $options = array());
+
+	/**
+	 * Check that the password handler is supported in this environment
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isSupported();
+
+	/**
+	 * Validate a password
+	 *
+	 * @param   string  $plaintext  The plain text password to validate
+	 * @param   string  $hashed     The password hash to validate against
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function validatePassword($plaintext, $hashed);
+}

--- a/src/Strategies/DatabaseStrategy.php
+++ b/src/Strategies/DatabaseStrategy.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Authentication\Strategies;
 
+use Joomla\Authentication\Password\HandlerInterface;
 use Joomla\Authentication\AbstractUsernamePasswordAuthenticationStrategy;
 use Joomla\Authentication\Authentication;
 use Joomla\Database\DatabaseDriver;
@@ -47,14 +48,17 @@ class DatabaseStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 	/**
 	 * Strategy Constructor
 	 *
-	 * @param   Input           $input     The input object from which to retrieve the request credentials.
-	 * @param   DatabaseDriver  $database  DatabaseDriver for retrieving user credentials.
-	 * @param   array           $options   Optional options array for configuring the credential storage connection.
+	 * @param   Input             $input            The input object from which to retrieve the request credentials.
+	 * @param   DatabaseDriver    $database         DatabaseDriver for retrieving user credentials.
+	 * @param   array             $options          Optional options array for configuring the credential storage connection.
+	 * @param   HandlerInterface  $passwordHandler  The password handler.
 	 *
 	 * @since   1.1.0
 	 */
-	public function __construct(Input $input, DatabaseDriver $database, array $options = array())
+	public function __construct(Input $input, DatabaseDriver $database, array $options = array(), HandlerInterface $passwordHandler = null)
 	{
+		parent::__construct($passwordHandler);
+
 		$this->input = $input;
 		$this->db    = $database;
 

--- a/src/Strategies/LocalStrategy.php
+++ b/src/Strategies/LocalStrategy.php
@@ -10,6 +10,7 @@ namespace Joomla\Authentication\Strategies;
 
 use Joomla\Authentication\AbstractUsernamePasswordAuthenticationStrategy;
 use Joomla\Authentication\Authentication;
+use Joomla\Authentication\Password\HandlerInterface;
 use Joomla\Input\Input;
 
 /**
@@ -38,14 +39,17 @@ class LocalStrategy extends AbstractUsernamePasswordAuthenticationStrategy
 	/**
 	 * Strategy Constructor
 	 *
-	 * @param   Input  $input            The input object from which to retrieve the request credentials.
-	 * @param   array  $credentialStore  Hash of username and hash pairs.
+	 * @param   Input             $input            The input object from which to retrieve the request credentials.
+	 * @param   array             $credentialStore  Hash of username and hash pairs.
+	 * @param   HandlerInterface  $passwordHandler  The password handler.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Input $input, $credentialStore)
+	public function __construct(Input $input, $credentialStore, HandlerInterface $passwordHandler = null)
 	{
-		$this->input = $input;
+		parent::__construct($passwordHandler);
+
+		$this->input           = $input;
 		$this->credentialStore = $credentialStore;
 	}
 

--- a/tests/Password/Argon2iHandlerTest.php
+++ b/tests/Password/Argon2iHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Authentication\Tests\Password;
+
+use Joomla\Authentication\Password\Argon2iHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for \Joomla\Authentication\Password\Argon2iHandler
+ */
+class Argon2iHandlerTest extends TestCase
+{
+	/**
+	 * Sets up the fixture, for example, open a network connection.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		if (!Argon2iHandler::isSupported())
+		{
+			$this->markTestSkipped('Argon2i algorithm is not supported.');
+		}
+
+		parent::setUp();
+	}
+
+	/**
+	 * @testdox  A password is hashed and validated
+	 *
+	 * @covers   Joomla\Authentication\Password\Argon2iHandler::hashPassword
+	 * @covers   Joomla\Authentication\Password\Argon2iHandler::validatePassword
+	 */
+	public function testAPasswordIsHashedAndValidated()
+	{
+		$handler = new Argon2iHandler;
+		$hash = $handler->hashPassword('password');
+		$this->assertTrue($handler->validatePassword('password', $hash), 'The hashed password was not validated.');
+	}
+}

--- a/tests/Password/BCryptHandlerTest.php
+++ b/tests/Password/BCryptHandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Authentication\Tests\Password;
+
+use Joomla\Authentication\Password\BCryptHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for \Joomla\Authentication\Password\BCryptHandler
+ */
+class BCryptHandlerTest extends TestCase
+{
+	/**
+	 * @testdox  A password is hashed and validated
+	 *
+	 * @covers   Joomla\Authentication\Password\BCryptHandler::hashPassword
+	 * @covers   Joomla\Authentication\Password\BCryptHandler::validatePassword
+	 */
+	public function testAPasswordIsHashedAndValidated()
+	{
+		$handler = new BCryptHandler;
+		$hash = $handler->hashPassword('password');
+		$this->assertTrue($handler->validatePassword('password', $hash), 'The hashed password was not validated.');
+	}
+}

--- a/tests/Strategies/LocalStrategyTest.php
+++ b/tests/Strategies/LocalStrategyTest.php
@@ -6,8 +6,10 @@
 
 namespace Joomla\Authentication\Tests\Strategies;
 
-use Joomla\Authentication\Strategies\LocalStrategy;
 use Joomla\Authentication\Authentication;
+use Joomla\Authentication\Password\HandlerInterface;
+use Joomla\Authentication\Strategies\LocalStrategy;
+use Joomla\Input\Input;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,11 +18,22 @@ use PHPUnit\Framework\TestCase;
 class LocalStrategyTest extends TestCase
 {
 	/**
+	 * @var  Input|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $input;
+
+	/**
+	 * @var  HandlerInterface|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $passwordHandler;
+
+	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 */
 	protected function setUp()
 	{
-		$this->input = $this->getMockBuilder('Joomla\\Input\\Input')->getMock();
+		$this->input           = $this->getMockBuilder('Joomla\\Input\\Input')->getMock();
+		$this->passwordHandler = $this->getMockBuilder('Joomla\\Authentication\\Password\\HandlerInterface')->getMock();
 	}
 
 	/**
@@ -32,11 +45,15 @@ class LocalStrategyTest extends TestCase
 			->method('get')
 			->willReturnArgument(0);
 
+		$this->passwordHandler->expects($this->any())
+			->method('validatePassword')
+			->willReturn(true);
+
 		$credentialStore = array(
 			'username' => '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJG'
 		);
 
-		$localStrategy = new LocalStrategy($this->input, $credentialStore);
+		$localStrategy = new LocalStrategy($this->input, $credentialStore, $this->passwordHandler);
 
 		$this->assertEquals('username', $localStrategy->authenticate());
 
@@ -52,11 +69,15 @@ class LocalStrategyTest extends TestCase
 			->method('get')
 			->willReturnArgument(0);
 
+		$this->passwordHandler->expects($this->any())
+			->method('validatePassword')
+			->willReturn(false);
+
 		$credentialStore = array(
 			'username' => '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH'
 		);
 
-		$localStrategy = new LocalStrategy($this->input, $credentialStore);
+		$localStrategy = new LocalStrategy($this->input, $credentialStore, $this->passwordHandler);
 
 		$this->assertEquals(false, $localStrategy->authenticate());
 
@@ -72,11 +93,14 @@ class LocalStrategyTest extends TestCase
 			->method('get')
 			->willReturn(false);
 
+		$this->passwordHandler->expects($this->never())
+			->method('validatePassword');
+
 		$credentialStore = array(
 			'username' => '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH'
 		);
 
-		$localStrategy = new LocalStrategy($this->input, $credentialStore);
+		$localStrategy = new LocalStrategy($this->input, $credentialStore, $this->passwordHandler);
 
 		$this->assertEquals(false, $localStrategy->authenticate());
 
@@ -92,11 +116,14 @@ class LocalStrategyTest extends TestCase
 			->method('get')
 			->willReturnArgument(0);
 
+		$this->passwordHandler->expects($this->never())
+			->method('validatePassword');
+
 		$credentialStore = array(
 			'jimbob' => '$2y$10$.vpEGa99w.WUetDFJXjMn.RiKRhZ/ImzxtOjtoJ0VFDV8S7ua0uJH'
 		);
 
-		$localStrategy = new LocalStrategy($this->input, $credentialStore);
+		$localStrategy = new LocalStrategy($this->input, $credentialStore, $this->passwordHandler);
 
 		$this->assertEquals(false, $localStrategy->authenticate());
 


### PR DESCRIPTION
### Summary of Changes

At present, our base authentication strategy only supports validating passwords against PHP's native password hashing API.  While this is generally best practice, it is inherently limiting (having a need to migrate from legacy hashes, using other properly secure options not available in the PHP engine, etc.).  So, this PR introduces an API to make this extendable.

Introduced is a new password handler interface with two functions; validating a password hash and generating a hash for a plaintext password.  Two implementations of the new interface are shipped; BCrypt and Argon2i handlers (one for each algorithm supported by PHP itself).

The handler is injectable into our shipped authentication strategy classes, by default the BCrypt handler is used if one is not injected.

### Testing Instructions

Use the new API to hash and validate a password, the unit tests demonstrate this functionality.

### Documentation Changes Required

New API use should be documented.