### PR TITLE
Updating phpstan to 2.0

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -77,7 +77,7 @@ local pipeline(name, phpversion, params) = {
                 depends: [ "composer" ],
                 failure: "ignore",
                 commands: [
-                    "vendor/bin/phpstan analyse src",
+                    "./vendor/bin/phpstan",
                 ]
             },
             {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -104,4 +104,5 @@ local pipeline(name, phpversion, params) = {
     pipeline("8.1", "8.1", "--prefer-stable"),
     pipeline("8.2", "8.2", "--prefer-stable"),
     pipeline("8.3", "8.3", "--prefer-stable"),
+    pipeline("8.4", "8.4", "--prefer-stable"),
 ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   image: joomlaprojects/docker-images:php8.1-ast
   name: phan
 - commands:
-  - vendor/bin/phpstan analyse src
+  - ./vendor/bin/phpstan
   depends:
   - composer
   failure: ignore

--- a/.drone.yml
+++ b/.drone.yml
@@ -130,6 +130,6 @@ volumes:
   name: composer-cache
 ---
 kind: signature
-hmac: 8603afe6767960fa19eb1a1027ed45b0d1135bc0dbf9d914e767b15414032ed4
+hmac: 573d078e0a6ad3830372c866d848699bf26e488dbfc3ae6b2e2128d476973df9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -129,7 +129,28 @@ volumes:
     path: /tmp/composer-cache
   name: composer-cache
 ---
+kind: pipeline
+name: PHP 8.4
+steps:
+- commands:
+  - php -v
+  - composer update --prefer-stable
+  image: joomlaprojects/docker-images:php8.4
+  name: composer
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+- commands:
+  - vendor/bin/phpunit
+  failure: ignore
+  image: joomlaprojects/docker-images:php8.4
+  name: PHPUnit
+volumes:
+- host:
+    path: /tmp/composer-cache
+  name: composer-cache
+---
 kind: signature
-hmac: 573d078e0a6ad3830372c866d848699bf26e488dbfc3ae6b2e2128d476973df9
+hmac: f1387a4d434258a2643c7617d2c49f93f57a2680d8a1e5c124778238d1a59d53
 
 ...

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "phpunit/phpunit": "^9.5.28",
         "symfony/phpunit-bridge": "^5.0",
         "squizlabs/php_codesniffer": "^3.7.2",
-        "phpstan/phpstan": "^1.10.7",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
         "phan/phan": "^5.4.2"
     },
     "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+
+includes:
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
+parameters:
+	level: 5
+	phpVersion: 80100
+	reportUnmatchedIgnoredErrors: false
+	paths:
+		- src


### PR DESCRIPTION
### Summary of Changes
This updates phpstan to version 2.0, adds a configuration file for phpstan and sets the level to 5, adds the deprecation plugin to it and changes the call in drone.

### Testing Instructions
Codereview
